### PR TITLE
Update index.html

### DIFF
--- a/local_file_example/index.html
+++ b/local_file_example/index.html
@@ -20,11 +20,11 @@
 		
 		<script>
 			//Create a map
-			var map = L.map('map', { maxZoom: 17});
+			var map = L.map('map', { maxZoom: 18});
 			
 			//Add Background Mapping
-			L.tileLayer('http://otile{s}.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png', {
-				attribution: '<a href="GISforThought.com">GISforThought</a> | <a href="http://blog.thematicmapping.org/2014/08/showing-geotagged-photos-on-leaflet-map.html">Leaflet.Photo</a> | &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a> | Tiles &copy; <a href="http://www.mapquest.com/" target="_blank">MapQuest</a> <img src="http://developer.mapquest.com/content/osm/mq_logo.png" />', subdomains: '1234'
+			L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				attribution: '<a href="GISforThought.com">GISforThought</a> | <a href="http://blog.thematicmapping.org/2014/08/showing-geotagged-photos-on-leaflet-map.html">Leaflet.Photo</a> | Base map data &copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
 			}).addTo(map);
 		
 			//Create the photolayer


### PR DESCRIPTION
Mapquest is no longer serving direct tile access as of July 11, 2016. Updated tileLayer to use OSM. Set maxZoom to 18 which is max for OSM tiles, for the rest of us.  : D

Thanks for your work on this, I had the same thoughts when I saw Bjorn's original blog for Leaflet.Photo. You might want to update your examples, as they show the dummy Mapquest tile now.
